### PR TITLE
Updates File.exists? signature to File.exist? to avoid deprecation warning

### DIFF
--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -147,8 +147,8 @@ module Heaven
       end
 
       def update_output
-        output.stderr = File.read(stderr_file) if File.exists?(stderr_file)
-        output.stdout = File.read(stdout_file) if File.exists?(stdout_file)
+        output.stderr = File.read(stderr_file) if File.exist?(stderr_file)
+        output.stdout = File.read(stdout_file) if File.exist?(stdout_file)
 
         output.update
       end


### PR DESCRIPTION
Occurs during test run

```
lib/heaven/provider/default_provider.rb:150:56: W: File.exists? is deprecated in favor of File.exist?.
        output.stderr = File.read(stderr_file) if File.exists?(stderr_file)
                                                       ^^^^^^^
lib/heaven/provider/default_provider.rb:151:56: W: File.exists? is deprecated in favor of File.exist?.
        output.stdout = File.read(stdout_file) if File.exists?(stdout_file)
                                                       ^^^^^^^
```