### PR TITLE
Fixes typo in Heaven::Jobs::Deployment.redis_lock_key

### DIFF
--- a/lib/heaven/jobs/deployment.rb
+++ b/lib/heaven/jobs/deployment.rb
@@ -9,7 +9,7 @@ module Heaven
 
       # Only allow one deployment per-environment at a time
       def self.redis_lock_key(guid, payload)
-        data = JSON.parse(payload)
+        data = JSON.parse(payload).try(:[], "deployment")
         if data["payload"] && data["payload"]["name"]
           name = data["payload"]["name"]
           return "#{name}-#{data["environment"]}-deployment"


### PR DESCRIPTION
@atmos not sure if that's the best way to fix this. ```script/cibuild``` passed.