### PR TITLE
Fix double deploys by locking properly

### DIFF
--- a/lib/heaven/jobs/deployment.rb
+++ b/lib/heaven/jobs/deployment.rb
@@ -9,7 +9,7 @@ module Heaven
 
       # Only allow one deployment per-environment at a time
       def self.redis_lock_key(guid, payload)
-        data = JSON.parse(payload)
+        data = JSON.parse(payload)["deployment"]
         if data["payload"] && data["payload"]["name"]
           name = data["payload"]["name"]
           return "#{name}-#{data["environment"]}-deployment"


### PR DESCRIPTION
The deployment payload format changed in October. https://developer.github.com/changes/2014-10-21-deployment-webhook-payload-changes/ This uses the nested keys.

Fixes #128