### PR TITLE
fix notifier user link when using Github Enterprise

### DIFF
--- a/lib/heaven/notifier/default.rb
+++ b/lib/heaven/notifier/default.rb
@@ -123,6 +123,10 @@ module Heaven
         "[#{repo_name}](#{repo_url(path)})"
       end
 
+      def octokit_web_endpoint
+        ENV["OCTOKIT_WEB_ENDPOINT"] || "https://github.com/"
+      end
+
       def default_message
         message = user_link
         case state
@@ -174,7 +178,7 @@ module Heaven
       end
 
       def user_link
-        "[#{chat_user}](https://github.com/#{chat_user})"
+        "[#{chat_user}](#{octokit_web_endpoint}#{chat_user})"
       end
 
       def output_link(link_title = "deployment")


### PR DESCRIPTION
The user link will default to https://github.com, which isn't right for Enterprise installs.