### PR TITLE
Better handling of timeouts

### DIFF
--- a/app/models/concerns/deployment_timeout.rb
+++ b/app/models/concerns/deployment_timeout.rb
@@ -2,23 +2,23 @@
 module DeploymentTimeout
   extend ActiveSupport::Concern
 
-  included do
-    attr_reader :start_time
-  end
-
   def timeout
     Integer(ENV["DEPLOYMENT_TIMEOUT"] || "300")
   end
 
-  def time_elapsed
-    ((start_time || Time.now) - Time.now).ceil
+  def deployment_time_elapsed
+    (Time.now - deployment_start_time).ceil
   end
 
-  def time_remaining
-    timeout - time_elapsed
+  def deployment_time_remaining
+    timeout - deployment_time_elapsed
   end
 
-  def start_deploy_timeout!
-    @start_time = Time.now
+  def deployment_start_time
+    @deployment_start_time || Time.now
+  end
+
+  def start_deployment_timeout!
+    @deployment_start_time = Time.now
   end
 end

--- a/app/models/concerns/deployment_timeout.rb
+++ b/app/models/concerns/deployment_timeout.rb
@@ -1,0 +1,24 @@
+# A module to handle deployment timeouts
+module DeploymentTimeout
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :start_time
+  end
+
+  def timeout
+    Integer(ENV["DEPLOYMENT_TIMEOUT"] || "300")
+  end
+
+  def time_elapsed
+    ((start_time || Time.now) - Time.now).ceil
+  end
+
+  def time_remaining
+    timeout - time_elapsed
+  end
+
+  def start_deploy_timeout!
+    @start_time = Time.now
+  end
+end

--- a/app/models/concerns/local_log_file.rb
+++ b/app/models/concerns/local_log_file.rb
@@ -1,5 +1,8 @@
 # A module to include for easy access to writing to a transient filesystem
 module LocalLogFile
+  extend ActiveSupport::Concern
+  include DeploymentTimeout
+
   def working_directory
     @working_directory ||= "/tmp/" + \
       Digest::SHA1.hexdigest([name_with_owner, github_token].join)
@@ -26,7 +29,7 @@ module LocalLogFile
   end
 
   def execute_and_log(cmds, env = {})
-    @last_child = POSIX::Spawn::Child.new(env.merge("HOME" => working_directory), *cmds)
+    @last_child = POSIX::Spawn::Child.new(env.merge("HOME" => working_directory), *cmds, execute_options)
 
     log_stdout(last_child.out)
     log_stderr(last_child.err)
@@ -36,5 +39,9 @@ module LocalLogFile
     end
 
     last_child
+  end
+
+  def execute_options
+    { :timeout => time_remaining }
   end
 end

--- a/app/models/concerns/local_log_file.rb
+++ b/app/models/concerns/local_log_file.rb
@@ -42,6 +42,14 @@ module LocalLogFile
   end
 
   def execute_options
-    { :timeout => time_remaining }
+    if terminate_child_process_on_timeout
+      { :timeout => deployment_time_remaining - 2 }
+    else
+      {}
+    end
+  end
+
+  def terminate_child_process_on_timeout
+    ENV["TERMINATE_CHILD_PROCESS_ON_TIMEOUT"] == "1"
   end
 end

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -22,6 +22,8 @@ end
 
 Jobs will timeout if they don't complete in 300 seconds. If you really need more than that you can configure the timeout by setting the `DEPLOYMENT_TIMEOUT` environmental variable to the number of seconds you'd like to increase it to.
 
+Heaven runs most of the deployment tasks in a child process, that by default does not die when the deployment timeouts. To enable terminating the deployment child processes, set `TERMINATE_CHILD_PROCESS_ON_TIMEOUT` to `1`.
+
 ## Heroku
 
 The heroku provider uses the [build and release API][13]. It requests an [archive link][14] from GitHub and passes that on to heroku. It polls the API every few seconds until the heroku build api completes.

--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -160,7 +160,7 @@ module Heaven
           notify
           record
         end
-      rescue Spawn::TimeoutExceeded, Timeout::Error => e
+      rescue POSIX::Spawn::TimeoutExceeded, Timeout::Error => e
         Rails.logger.info e.message
         Rails.logger.info e.backtrace
         outuput.stderr += "\n\nDEPLOYMENT TIMED OUT AFTER #{timeout} SECONDS"

--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -154,12 +154,16 @@ module Heaven
 
       def run!
         Timeout.timeout(timeout) do
-          start_deploy_timeout!
+          start_deployment_timeout!
           setup
           execute unless Rails.env.test?
           notify
           record
         end
+      rescue Spawn::TimeoutExceeded, Timeout::Error => e
+        Rails.logger.info e.message
+        Rails.logger.info e.backtrace
+        outuput.stderr += "\n\nDEPLOYMENT TIMED OUT AFTER #{timeout} SECONDS"
       rescue StandardError => e
         Rails.logger.info e.message
         Rails.logger.info e.backtrace

--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -4,6 +4,7 @@ module Heaven
     # The super class provider, all providers inherit from this.
     class DefaultProvider
       include ApiClient
+      include DeploymentTimeout
       include LocalLogFile
 
       attr_accessor :credentials, :guid, :last_child, :name, :data
@@ -138,10 +139,6 @@ module Heaven
                           :sha             => sha)
       end
 
-      def timeout
-        Integer(ENV["DEPLOYMENT_TIMEOUT"] || "300")
-      end
-
       def update_output
         output.stderr = File.read(stderr_file) if File.exist?(stderr_file)
         output.stdout = File.read(stdout_file) if File.exist?(stdout_file)
@@ -157,6 +154,7 @@ module Heaven
 
       def run!
         Timeout.timeout(timeout) do
+          start_deploy_timeout!
           setup
           execute unless Rails.env.test?
           notify


### PR DESCRIPTION
Adds the ability to use POSIX::Spawn timeouts to actually kill the deployment processes when hitting a timeout. It seems that the current ruby timeout leaves the processes running. The behavior is controlled with `TERMINATE_CHILD_PROCESS_ON_TIMEOUT` env. 

The processes are killed a bit before the ruby timeout hits. The 2 seconds is just something I pulled out of thin air so I'm all in for changing it to something. 

This also catches both kinds of timeouts in deployments and appends a notification to the error log that there was a timeout so this pr also kind of takes care of rest of the issues in #88.

We'll need to run this for a while ourselves to test how this actually performs, but opened this for initial thoughts.