### PR TITLE
Fix typo in deployment timeout handling

### DIFF
--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -163,7 +163,7 @@ module Heaven
       rescue POSIX::Spawn::TimeoutExceeded, Timeout::Error => e
         Rails.logger.info e.message
         Rails.logger.info e.backtrace
-        outuput.stderr += "\n\nDEPLOYMENT TIMED OUT AFTER #{timeout} SECONDS"
+        output.stderr += "\n\nDEPLOYMENT TIMED OUT AFTER #{timeout} SECONDS"
       rescue StandardError => e
         Rails.logger.info e.message
         Rails.logger.info e.backtrace


### PR DESCRIPTION
A deployment timeout caused a throw because of a typo.