### PR TITLE
Shell provider

### DIFF
--- a/doc/providers.md
+++ b/doc/providers.md
@@ -247,3 +247,11 @@ applications.
 [19]: https://devcenter.heroku.com/articles/releases
 [20]: https://github.com/atmos/hubot-deploy
 [21]: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/Welcome.html
+
+## Shell provider
+
+Shell provider lets you run an arbitrary script from the repo to perform the deployment. The script receives `BRANCH`, `SHA`, `DEPLOY_TASK` and `DEPLOY_ENV` environment variables when executing. This is ideal provider if your deployment consists only of for example asset compilation and upload to S3.
+
+### Required Configuration
+
+No configuration required in heaven. You must add `"deploy_script"` key to your `apps.json` configuration that must point to an executable file inside the repository.

--- a/lib/heaven/provider.rb
+++ b/lib/heaven/provider.rb
@@ -17,7 +17,8 @@ module Heaven
       "fabric"             => Fabric,
       "elastic_beanstalk"  => ElasticBeanstalk,
       "bundler_capistrano" => BundlerCapistrano,
-      "ansible"            => Ansible
+      "ansible"            => Ansible,
+      "shell"              => Shell
     }
 
     def self.from(guid, data)

--- a/lib/heaven/provider.rb
+++ b/lib/heaven/provider.rb
@@ -6,6 +6,7 @@ require "heaven/provider/elastic_beanstalk"
 require "heaven/provider/dpl"
 require "heaven/provider/bundler_capistrano"
 require "heaven/provider/ansible"
+require "heaven/provider/shell"
 
 # The top-level Heaven module
 module Heaven

--- a/lib/heaven/provider/shell.rb
+++ b/lib/heaven/provider/shell.rb
@@ -1,0 +1,59 @@
+module Heaven
+  # Top-level module for providers.
+  module Provider
+    # The capistrano provider.
+    class Shell < DefaultProvider
+      def initialize(guid, payload)
+        super
+        @name = "shell"
+      end
+
+      def execute
+        return execute_and_log(["/usr/bin/true"]) if Rails.env.test?
+
+        unless File.exist?(checkout_directory)
+          log "Cloning #{repository_url} into #{checkout_directory}"
+          execute_and_log(["git", "clone", clone_url, checkout_directory])
+        end
+
+        Dir.chdir(checkout_directory) do
+          log "Fetching the latest code"
+          execute_and_log(%w{git fetch})
+          execute_and_log(["git", "reset", "--hard", sha])
+          log "Executing script: #{deployment_command}"
+          execute_and_log(deployment_command, deployment_environment)
+        end
+      end
+
+      private
+
+      def deployment_command
+        script = custom_payload_config.try(:[], "deploy_script")
+        unless script
+          fail "No deploy script configured."
+        end
+        unless script ~= /\A\w+(\/\w+)*\Z/
+          fail "Only deploy scripts from the repo are allowed."
+        end
+        "./" + script
+      end
+
+      def deployment_environment
+        {
+          "BRANCH" => ref,
+          "SHA" => sha,
+          "DEPLOY_ENV" => environment,
+          "DEPLOY_TASK" => task
+        }
+      end
+
+      def task
+        name = deployment_data["task"] || "deploy"
+        unless name =~ /deploy(?:\:[\w+:]+)?/
+          fail "Invalid taskname: #{name.inspect}"
+        end
+        name
+      end
+    end
+  end
+end

--- a/lib/heaven/provider/shell.rb
+++ b/lib/heaven/provider/shell.rb
@@ -31,7 +31,7 @@ module Heaven
         script = custom_payload_config.try(:[], "deploy_script")
         fail "No deploy script configured." unless script
         fail "Only deploy scripts from the repo are allowed." unless script =~ /\A([\w-]+\/)*[\w-]+(\.\w+)?\Z/
-        fail "Deploy script #{path} not found or not executable" unless File.executable?("./" + script)
+        fail "Deploy script #{script} not found or not executable" unless File.executable?("./" + script)
         "./" + script
       end
 

--- a/lib/heaven/provider/shell.rb
+++ b/lib/heaven/provider/shell.rb
@@ -21,7 +21,7 @@ module Heaven
           execute_and_log(%w{git fetch})
           execute_and_log(["git", "reset", "--hard", sha])
           log "Executing script: #{deployment_command}"
-          execute_and_log(deployment_command, deployment_environment)
+          execute_and_log([deployment_command], deployment_environment)
         end
       end
 

--- a/lib/heaven/provider/shell.rb
+++ b/lib/heaven/provider/shell.rb
@@ -32,7 +32,7 @@ module Heaven
         unless script
           fail "No deploy script configured."
         end
-        unless script ~= /\A\w+(\/\w+)*\Z/
+        unless script =~ /\A([\w-]+\/)*[\w-]+(\.\w+)?\Z/
           fail "Only deploy scripts from the repo are allowed."
         end
         "./" + script

--- a/lib/heaven/provider/shell.rb
+++ b/lib/heaven/provider/shell.rb
@@ -29,12 +29,9 @@ module Heaven
 
       def deployment_command
         script = custom_payload_config.try(:[], "deploy_script")
-        unless script
-          fail "No deploy script configured."
-        end
-        unless script =~ /\A([\w-]+\/)*[\w-]+(\.\w+)?\Z/
-          fail "Only deploy scripts from the repo are allowed."
-        end
+        fail "No deploy script configured." unless script
+        fail "Only deploy scripts from the repo are allowed." unless script =~ /\A([\w-]+\/)*[\w-]+(\.\w+)?\Z/
+        fail "Deploy script #{path} not found or not executable" unless File.executable?("./" + script)
         "./" + script
       end
 


### PR DESCRIPTION
A provider that just executes a file from the repository as the deployment task. This is suitable in cases when you're only deploying for example a project that's only frontend assets, so the deployment is just asset compilation and push to S3.

The provider validates that the deploy script is a file inside the repo so arbitrary commands cannot be run. The script to be run can be given in the provider configuration.