### PR TITLE
Run shell provider in a clean bundler environment

### DIFF
--- a/lib/heaven/provider/shell.rb
+++ b/lib/heaven/provider/shell.rb
@@ -20,8 +20,10 @@ module Heaven
           log "Fetching the latest code"
           execute_and_log(%w{git fetch})
           execute_and_log(["git", "reset", "--hard", sha])
-          log "Executing script: #{deployment_command}"
-          execute_and_log([deployment_command], deployment_environment)
+          Bundler.with_clean_env do
+            log "Executing script: #{deployment_command}"
+            execute_and_log([deployment_command], deployment_environment)
+          end
         end
       end
 


### PR DESCRIPTION
`execute_and_log` eventually forks a child that runs the `deployment_command`. Unfortunately Heaven's Bundler environment leaks to that process, so deploy scripts are not able to use their own instance of Bundler.

Running the `deployment_command` inside `Bundler.with_clean_env` should fix the issue.