### PR TITLE
Support other prefixes

### DIFF
--- a/app/services/environment_locker.rb
+++ b/app/services/environment_locker.rb
@@ -1,8 +1,8 @@
 # A class for lock/unlocking a repo's environment
 class EnvironmentLocker
-  LOCK_TASK     = "deploy:lock"
-  UNLOCK_TASK   = "deploy:unlock"
-  UNKNOWN_ACTOR = "Unknown"
+  LOCK_TASK     = "lock".freeze
+  UNLOCK_TASK   = "unlock".freeze
+  UNKNOWN_ACTOR = "Unknown".freeze
 
   attr_reader :name_with_owner, :environment, :actor, :task
   attr_writer :redis
@@ -15,11 +15,12 @@ class EnvironmentLocker
   end
 
   def lock?
-    task == LOCK_TASK
+    
+    task == "#{prefix}:#{LOCK_TASK}"
   end
 
   def unlock?
-    task == UNLOCK_TASK
+    task == "#{prefix}:#{UNLOCK_TASK}"
   end
 
   def lock!
@@ -46,5 +47,9 @@ class EnvironmentLocker
 
   def redis_key
     [name_with_owner, environment, "lock"].join("-")
+  end
+  
+  def prefix
+    ENV['HUBOT_DEPLOY_PREFIX'] || 'deploy'
   end
 end

--- a/app/services/environment_locker.rb
+++ b/app/services/environment_locker.rb
@@ -15,7 +15,6 @@ class EnvironmentLocker
   end
 
   def lock?
-    
     task == "#{prefix}:#{LOCK_TASK}"
   end
 
@@ -48,8 +47,8 @@ class EnvironmentLocker
   def redis_key
     [name_with_owner, environment, "lock"].join("-")
   end
-  
+
   def prefix
-    ENV['HUBOT_DEPLOY_PREFIX'] || 'deploy'
+    ENV["HUBOT_DEPLOY_PREFIX"] || "deploy"
   end
 end

--- a/spec/services/environment_locker_spec.rb
+++ b/spec/services/environment_locker_spec.rb
@@ -18,6 +18,15 @@ describe EnvironmentLocker do
 
       expect(locker.lock?).to be_true
     end
+
+    it "allows a custom prefix" do
+      ENV['HUBOT_DEPLOY_PREFIX'] = 'ship'
+
+      locker = EnvironmentLocker.new(lock_params.merge(:task => "ship:lock"))
+      locker.redis = redis
+
+      expect(locker.lock?).to be_true
+    end
   end
 
   describe "#unlock?" do
@@ -26,6 +35,15 @@ describe EnvironmentLocker do
       locker.redis = redis
 
       expect(locker.unlock?).to be_true
+    end
+
+    it "allows a custom prefix" do
+      ENV['HUBOT_DEPLOY_PREFIX'] = 'ship'
+
+      locker = EnvironmentLocker.new(lock_params.merge(:task => "ship:unlock"))
+      locker.redis = redis
+
+      expect(locker.lock?).to be_true
     end
   end
 

--- a/spec/services/environment_locker_spec.rb
+++ b/spec/services/environment_locker_spec.rb
@@ -19,13 +19,13 @@ describe EnvironmentLocker do
       expect(locker.lock?).to be_true
     end
 
-    it "allows a custom prefix" do
-      ENV['HUBOT_DEPLOY_PREFIX'] = 'ship'
+    context "with hubot deploy prefix" do
+      before { stub_const("ENV", "HUBOT_DEPLOY_PREFIX" => "ship") }
 
-      locker = EnvironmentLocker.new(lock_params.merge(:task => "ship:lock"))
-      locker.redis = redis
-
-      expect(locker.lock?).to be_true
+      it "is true if the task is ship:lock" do
+        locker = EnvironmentLocker.new(lock_params.merge(:task => "ship:lock"))
+        expect(locker.lock?).to be_true
+      end
     end
   end
 
@@ -37,13 +37,13 @@ describe EnvironmentLocker do
       expect(locker.unlock?).to be_true
     end
 
-    it "allows a custom prefix" do
-      ENV['HUBOT_DEPLOY_PREFIX'] = 'ship'
+    context "with hubot deploy prefix" do
+      before { stub_const("ENV", "HUBOT_DEPLOY_PREFIX" => "ship") }
 
-      locker = EnvironmentLocker.new(lock_params.merge(:task => "ship:unlock"))
-      locker.redis = redis
-
-      expect(locker.lock?).to be_true
+      it "is true if the task is ship:unlock" do
+        locker = EnvironmentLocker.new(lock_params.merge(:task => "ship:unlock"))
+        expect(locker.unlock?).to be_true
+      end
     end
   end
 


### PR DESCRIPTION
Useful if you want to say "ship" instead of deploy