### PR TITLE
Allow Slack notification customisation

### DIFF
--- a/doc/notifications.md
+++ b/doc/notifications.md
@@ -24,6 +24,8 @@ end
 | Environmental Variables |                                                 |
 |-------------------------|-------------------------------------------------|
 | SLACK_WEBHOOK_URL       | A Slack Webhook URL from [incoming-webhook][21] section of Slack|
+| SLACK_BOT_NAME          | The name to post to Slack as. Defaults to `hubot`|
+| SLACK_BOT_ICON          | The icon to use for the notification. Defaults to `https://octodex.github.com/images/labtocat.png`|
 
 ## Campfire
 

--- a/lib/heaven/notifier/slack.rb
+++ b/lib/heaven/notifier/slack.rb
@@ -14,8 +14,8 @@ module Heaven
         output_message << "##{deployment_number} - #{repo_name} / #{ref} / #{environment}"
         slack_account.ping "",
           :channel     => "##{chat_room}",
-          :username    => "hubot",
-          :icon_url    => "https://octodex.github.com/images/labtocat.png",
+          :username    => slack_bot_name,
+          :icon_url    => slack_bot_icon,
           :attachments => [{
             :text    => filtered_message,
             :color   => green? ? "good" : "danger",
@@ -55,6 +55,14 @@ module Heaven
 
       def slack_webhook_url
         ENV["SLACK_WEBHOOK_URL"]
+      end
+
+      def slack_bot_name
+        ENV["SLACK_BOT_NAME"] || "hubot"
+      end
+
+      def slack_bot_icon
+        ENV["SLACK_BOT_ICON"] || "https://octodex.github.com/images/labtocat.png"
       end
 
       def slack_account


### PR DESCRIPTION
Allow Slack notifications to have a custom name and/or icon.