### PR TITLE
Pass the correct environment parameter to api deployment creation

### DIFF
--- a/app/models/auto_deployment.rb
+++ b/app/models/auto_deployment.rb
@@ -34,7 +34,11 @@ class AutoDeployment
 
   def create_deployment
     description = "Heaven auto deploy triggered by a commit status change"
-    api.create_deployment(name_with_owner, sha, :payload => updated_payload, :description => description)
+    api.create_deployment(name_with_owner, sha,
+      :payload => updated_payload,
+      :environment => deployment.environment,
+      :description => description
+    )
   end
 
   def execute


### PR DESCRIPTION
Should fixup https://github.com/atmos/heaven/issues/103, previously every environment defaulted to production.

@filipegiusti Is this what you're getting at?