### PR TITLE
Use new buildpacks specification

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/heroku/heroku-buildpack-python.git

--- a/app.json
+++ b/app.json
@@ -34,7 +34,6 @@
       "description": "The maximum amount of time a deployment can take in seconds.",
       "value": "300"
     },
-    "BUILDPACK_URL": "https://github.com/ddollar/heroku-buildpack-multi.git",
     "RAILS_ENV": {
       "description": "This is what the RAILS_ENV unix environmental variable is set to.",
       "value": "production"
@@ -54,5 +53,9 @@
   ],
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate"
-  }
+  },
+  "buildpacks": [
+    { "url": "https://github.com/heroku/heroku-buildpack-ruby.git" },
+    { "url": "https://github.com/heroku/heroku-buildpack-python.git" }
+  ]
 }


### PR DESCRIPTION
Heroku has first-class support for multiple buildpacks now, so ddollar's buildpack isn't necessary anymore. This PR removes .buildpacks and adds the ruby and python buildpacks to app.json. For existing apps, you'll need to run something like:

```
heroku buildpacks:set https://github.com/heroku/heroku-buildpack-ruby.git
heroku buildpacks:add https://github.com/heroku/heroku-buildpack-python.git
```

And possibly:

```
heroku config:unset BUILDPACK_URL
```