### PR TITLE
log commands when using execute_and_log()

### DIFF
--- a/app/models/concerns/local_log_file.rb
+++ b/app/models/concerns/local_log_file.rb
@@ -36,6 +36,7 @@ module LocalLogFile
     #   cmds = ["my_command", "foo=bar lazy=true"]
     @last_child = POSIX::Spawn::Child.new(env.merge("HOME" => working_directory), *cmds, execute_options)
 
+    log_stdout("$ #{cmds.join(" ")}\n")
     log_stdout(last_child.out)
     log_stderr(last_child.err)
 


### PR DESCRIPTION
so that we can tell what command has been executed and how the result of `stdout` is produced