### PR TITLE
Remove bundler capistrano -s parameter

### DIFF
--- a/doc/providers.md
+++ b/doc/providers.md
@@ -179,6 +179,16 @@ end
     |                       |                     |
 ```
 
+## Bundler Capistrano
+
+Bundler enabled Capistrano deployment lets you deploy using Capistrano in a fresh bundler environment. The provider will install the gems from your project's `:deployment` and `:heaven` groups and use that environment to run Capistrano. The same configuration applies for Bundler Capistrano than for Capistrano provider. One caveat:
+
+The provider passes the ref being deployed to capistrano in an environment variable `BRANCH`. In your `Capfile`, you'll need to add:
+
+```ruby
+set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
+```
+
 ## Fabric
 
 Fabric enables distributed task management system over ssh. The heaven provider gives you support for three options.

--- a/lib/heaven/provider/bundler_capistrano.rb
+++ b/lib/heaven/provider/bundler_capistrano.rb
@@ -26,7 +26,7 @@ module Heaven
             bundler_string = ["bundle", "install", "--without", ignored_groups.join(" ")]
             log "Executing bundler: #{bundler_string.join(" ")}"
             execute_and_log(bundler_string)
-            deploy_string = ["bundle", "exec", "cap", environment, "-s", "branch=#{ref}", task]
+            deploy_string = ["bundle", "exec", "cap", environment, task]
             log "Executing capistrano: #{deploy_string.join(" ")}"
             execute_and_log(deploy_string, "BRANCH" => ref)
           end


### PR DESCRIPTION
This makes bundler_capistrano provider support all of capistrano 2.x,
3.x as well as >=3.4. The branch is passed in an environment variable
for all and this might need just a minor modification to the
deployment config. 3.4 starts to throw up when the -s arguments are
present.

See discussion in https://github.com/atmos/heaven/commit/8b2921bddf72e6bfdc6cc8ab319c5ad16523e6a2.