### PR TITLE
Make the new archive format work on Heroku

### DIFF
--- a/lib/heaven/provider/bundler_capistrano.rb
+++ b/lib/heaven/provider/bundler_capistrano.rb
@@ -11,7 +11,7 @@ module Heaven
       end
 
       def archive_name
-        "#{name}-#{sha}.tar.gz"
+        "#{name_without_owner}-#{sha}.tar.gz"
       end
 
       def archive_link
@@ -23,7 +23,7 @@ module Heaven
       end
 
       def unpacked_directory
-        @unpacked_directory ||= archive_path.chomp(".tar.gz")
+        @unpacked_directory ||= "#{working_directory}/#{name_with_owner.gsub("/", "-")}-#{full_sha}"
       end
 
       def execute
@@ -31,12 +31,12 @@ module Heaven
 
         unless File.exist?(archive_path)
           log "Downloading #{archive_link} into #{archive_path}"
-          execute_and_log(["curl", "-L", archive_link, ">", archive_path])
+          execute_and_log(["curl", "-sL", archive_link, "-o", archive_path])
         end
 
         unless Dir.exist?(unpacked_directory)
           log "Unpacking tarball"
-          execute_and_log(["tar", "xzf", archive_path])
+          execute_and_log(["tar", "-C", working_directory, "-xzf", archive_path])
         end
 
         Dir.chdir(unpacked_directory) do

--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -57,8 +57,16 @@ module Heaven
         data["repository"]["full_name"]
       end
 
+      def name_without_owner
+        data["repository"]["name"]
+      end
+
       def sha
         deployment_data["sha"][0..7]
+      end
+
+      def full_sha
+        deployment_data["sha"]
       end
 
       def ref


### PR DESCRIPTION
We use built-in flags for both `curl` and `tar` to ensure that the archive
files are going where we want them to.

The directory format inside the GitHub tarball is this:

`<owner/organization name>-<repository name>-<full-sha-hash>`

so we create the `unpacked_directory` in this format.

Fixes changes made in #166. Would be good if @maletor has a look too.