### PR TITLE
Allow private bundler sources

### DIFF
--- a/app.json
+++ b/app.json
@@ -49,6 +49,14 @@
     "REDIS_PROVIDER": {
       "description": "Redis config var to use",
       "value": "REDIS_URL"
+    },
+    "BUNDLER_PRIVATE_SOURCE": {
+      "description": "Private gem source. Optional.",
+      "required": false
+    },
+    "BUNDLER_PRIVATE_CREDENTIALS": {
+      "description": "Private gem source credentials. Optional.",
+      "required": false
     }
   },
   "formation": [

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -189,6 +189,11 @@ The provider passes the ref being deployed to capistrano in an environment varia
 set :branch, (ENV['BRANCH'] || fetch(:branch, 'master'))
 ```
 
+| Environmental Variables     |                                                                                                 |
+|-----------------------------|-------------------------------------------------------------------------------------------------|
+| BUNDLER_PRIVATE_SOURCE      | Private gem source. _Optional._                                                                 |
+| BUNDLER_PRIVATE_CREDENTIALS | Private gem source credentials. Can be a token or a username:password combination. _Optional._  |
+
 ## Fabric
 
 Fabric enables distributed task management system over ssh. The heaven provider gives you support for three options.

--- a/lib/heaven/provider/bundler_capistrano.rb
+++ b/lib/heaven/provider/bundler_capistrano.rb
@@ -41,6 +41,12 @@ module Heaven
 
         Dir.chdir(unpacked_directory) do
           Bundler.with_clean_env do
+            if bundler_private_source.present? && bundler_private_credentials.present?
+              bundler_config_string = ["bundle", "config", bundler_private_source, bundler_private_credentials]
+              log "Adding bundler config"
+              execute_and_log(bundler_config_string)
+            end
+
             bundler_string = ["bundle", "install", "--without", ignored_groups.join(" ")]
             log "Executing bundler: #{bundler_string.join(" ")}"
             execute_and_log(bundler_string)
@@ -61,6 +67,14 @@ module Heaven
         gemfile_path = File.expand_path("Gemfile", unpacked_directory)
         lockfile_path = File.expand_path("Gemfile.lock", unpacked_directory)
         Bundler::Definition.build(gemfile_path, lockfile_path, nil)
+      end
+
+      def bundler_private_source
+        ENV["BUNDLER_PRIVATE_SOURCE"]
+      end
+
+      def bundler_private_credentials
+        ENV["BUNDLER_PRIVATE_CREDENTIALS"]
       end
     end
   end


### PR DESCRIPTION
This allows us to use a *single* private bundler source without storing
the private credentials in our `Gemfile.lock`

Replaces #147