### PR TITLE
Create Environment model for better organization

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -1,18 +1,19 @@
 # A record of a deployment processes
 class Deployment < ActiveRecord::Base
-  validates_presence_of :name, :name_with_owner
+  validates :name, :name_with_owner, :environment, :repository, presence: true
 
+  belongs_to :environment
   belongs_to :repository
 
   def self.latest_for_name_with_owner(name_with_owner)
-    sets = self.select(:name, :environment)
+    sets = self.select(:name, :environment_id)
       .where(:name_with_owner => name_with_owner)
-      .group("name,environment")
+      .group([:name, :environment_id])
 
     sets.map do |deployment|
       params = {
         :name            => deployment.name,
-        :environment     => deployment.environment,
+        :environment_id  => deployment.environment_id,
         :name_with_owner => name_with_owner
       }
       Deployment.where(params).order("created_at desc").limit(1)

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,0 +1,5 @@
+class Environment < ActiveRecord::Base
+  validates :name, presence: true, uniqueness: true
+
+  has_many :deployments, dependent: :delete_all
+end

--- a/db/migrate/20150903184055_add_repositories_indexes.rb
+++ b/db/migrate/20150903184055_add_repositories_indexes.rb
@@ -1,0 +1,5 @@
+class AddRepositoriesIndexes < ActiveRecord::Migration
+  def change
+    add_index :repositories, [:owner, :name], unique: true
+  end
+end

--- a/db/migrate/20150903204319_create_environments.rb
+++ b/db/migrate/20150903204319_create_environments.rb
@@ -1,0 +1,33 @@
+class CreateEnvironments < ActiveRecord::Migration
+  def up
+    create_table :environments do |t|
+      t.string :name, required: true, index: true, unique: true
+      t.timestamps
+    end
+
+    add_column :deployments, :environment_id, :integer
+
+    Deployment.connection.schema_cache.clear!
+    Deployment.reset_column_information
+    Deployment.find_each do |deployment|
+      deployment.update_column(:environment_id, Environment.where(name: deployment.read_attribute(:environment)).first_or_create!.id)
+    end
+
+    change_column :deployments, :environment_id, :integer, null: false
+    remove_column :deployments, :environment
+  end
+
+  def down
+    add_column :deployments, :environment, :string, default: "production"
+
+    Deployment.connection.schema_cache.clear!
+    Deployment.reset_column_information
+    Deployment.includes(:environment).find_each do |deployment|
+      deployment.update_column(:environment, Environment.find(deployment.environment_id).first!.name)
+    end
+
+    remove_column :deployments, :environment_id
+
+    drop_table :environments
+  end
+end

--- a/db/migrate/20150904161019_add_avatar_url_for_deployments.rb
+++ b/db/migrate/20150904161019_add_avatar_url_for_deployments.rb
@@ -1,0 +1,9 @@
+class AddAvatarUrlForDeployments < ActiveRecord::Migration
+  def change
+    add_column :deployments, :sender_login, :string
+    add_column :deployments, :sender_avatar_url, :string
+    add_index :deployments, [:repository_id, :environment_id]
+    add_index :deployments, [:name, :environment_id, :name_with_owner], name: "index_deployments_on_latest_for_name_with_owner"
+    add_index :deployments, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140728040201) do
+ActiveRecord::Schema.define(version: 20150904161019) do
 
   create_table "deployments", force: :cascade do |t|
     t.text     "custom_payload"
-    t.string   "environment",     default: "production"
     t.string   "guid"
     t.string   "name"
     t.string   "name_with_owner"
@@ -25,7 +24,22 @@ ActiveRecord::Schema.define(version: 20140728040201) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "repository_id"
+    t.integer  "environment_id",  null: false
+    t.string   "sender"
+    t.string   "avatar_url"
   end
+
+  add_index "deployments", ["created_at"], name: "index_deployments_on_created_at"
+  add_index "deployments", ["name", "environment_id", "name_with_owner"], name: "index_deployments_on_latest_for_name_with_owner"
+  add_index "deployments", ["repository_id", "environment_id"], name: "index_deployments_on_repository_id_and_environment_id"
+
+  create_table "environments", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "environments", ["name"], name: "index_environments_on_name"
 
   create_table "repositories", force: :cascade do |t|
     t.string   "owner"
@@ -34,5 +48,7 @@ ActiveRecord::Schema.define(version: 20140728040201) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "repositories", ["owner", "name"], name: "index_repositories_on_owner_and_name", unique: true
 
 end

--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -61,6 +61,14 @@ module Heaven
         data["repository"]["name"]
       end
 
+      def sender_login
+        data["sender"]["login"]
+      end
+
+      def sender_avatar_url
+        data["sender"]["avatar_url"]
+      end
+
       def sha
         deployment_data["sha"][0..7]
       end
@@ -137,14 +145,16 @@ module Heaven
       end
 
       def record
-        Deployment.create(:custom_payload  => JSON.dump(custom_payload),
-                          :environment     => environment,
-                          :guid            => guid,
-                          :name            => name,
-                          :name_with_owner => name_with_owner,
-                          :output          => output.url,
-                          :ref             => ref,
-                          :sha             => sha)
+        Deployment.create(:custom_payload    => JSON.dump(custom_payload),
+                          :environment       => environment,
+                          :guid              => guid,
+                          :name              => name,
+                          :name_with_owner   => name_with_owner,
+                          :output            => output.url,
+                          :ref               => ref,
+                          :sha               => sha,
+                          :sender_login      => sender_login,
+                          :sender_avatar_url => sender_avatar_url)
       end
 
       def update_output

--- a/spec/models/deployment_spec.rb
+++ b/spec/models/deployment_spec.rb
@@ -6,10 +6,15 @@ describe Deployment do
   let(:payload) { fixture_data("deployment") }
   let!(:data) { JSON.parse(payload)["payload"] }
 
+  let(:repository) { Repository.where(owner: "atmos", name: "heaven").first_or_create! }
+  let(:production) { Environment.where(name: "production").first_or_create! }
+  let(:staging) { Environment.where(name: "staging").first_or_create! }
+
   let!(:create_data) do
     {
       :custom_payload  => JSON.dump(data),
-      :environment     => "production",
+      :repository      => repository,
+      :environment     => production,
       :guid            => SecureRandom.uuid,
       :name            => "hubot",
       :name_with_owner => "github/hubot",
@@ -34,7 +39,7 @@ describe Deployment do
 
     Deployment.create create_data.merge(:name_with_owner => "atmos/heaven")
 
-    present << Deployment.create(create_data.merge(:environment => "staging"))
+    present << Deployment.create(create_data.merge(:environment => staging))
 
     deployments = Deployment.latest_for_name_with_owner("github/hubot")
 

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Environment do
+  it "doesn't recreate environments with the same name" do
+    expect(Environment.create(name: "production")).to be_valid
+    expect {
+      Environment.create!(name: "production")
+    }.to raise_exception
+  end
+end


### PR DESCRIPTION
I have a private fork of this repository which has quite a few changes which I'd like to push up if you're interested. Fundamentally, nothing is different in terms of deployments, however, we needed a UI for our needs. It's fairly simple but gives great visibility when you have dozens of applications and environments. This PR has some modifications to the models to support it.

1. Create `Environment` model for better organization. This allows us to do grouping and ordering via the database query.
2. `Deployment` now stores the sender's username and avatar url which can be used in the future for views as that information isn't persisted.
3. Some indexes were added for optimization.

What are your thoughts on having a UI as part of this repository? It won't perform any actions itself, purely a view of what's been done. If you'd rather not, I suppose I can always keep just that portion in our fork.