### PR TITLE
Remove default value for GITHUB_TEAM_ID

### DIFF
--- a/config/initializers/warden-github.rb
+++ b/config/initializers/warden-github.rb
@@ -5,7 +5,7 @@ Warden::GitHub::Rails.setup do |config|
                            :client_secret => ENV['GITHUB_CLIENT_SECRET'],
                            :scope         => ["read:org"]
 
-  config.add_team :employees, ENV['GITHUB_TEAM_ID'] || '<unknown-team-id>'
+  config.add_team :employees, ENV['GITHUB_TEAM_ID'] if ENV['GITHUB_TEAM_ID'].present?
 
   config.default_scope = :user
 end

--- a/config/initializers/warden-github.rb
+++ b/config/initializers/warden-github.rb
@@ -5,7 +5,7 @@ Warden::GitHub::Rails.setup do |config|
                            :client_secret => ENV['GITHUB_CLIENT_SECRET'],
                            :scope         => ["read:org"]
 
-  config.add_team :employees, ENV['GITHUB_TEAM_ID'] || '696075'
+  config.add_team :employees, ENV['GITHUB_TEAM_ID'] || '<unknown-team-id>'
 
   config.default_scope = :user
 end


### PR DESCRIPTION
Uses a dummy placeholder instead, similarly to [api_client.rb](https://github.com/atmos/heaven/blob/v0.9.0/app/models/concerns/api_client.rb).

Closes #183 