### PR TITLE
Display a user_name if present

### DIFF
--- a/lib/heaven/notifier/default.rb
+++ b/lib/heaven/notifier/default.rb
@@ -100,7 +100,8 @@ module Heaven
       end
 
       def chat_user
-        deployment_payload["notify"]["user"] || "unknown"
+        deployment_payload["notify"]["user_name"] ||
+          deployment_payload["notify"]["user"] || "unknown"
       end
 
       def chat_room


### PR DESCRIPTION
Slack started receiving user's ids as the username with recent changes to hubot-deploy. This makes notifiers in heaven not work as expected since they don't necessarily have an easy way to look up the user id. This introduces a new payload variable that can be set that passes through to the old behavior of the attribute is absent.

/cc https://github.com/atmos/hubot-deploy/pull/101