### PR TITLE
Put SSH private key into user's actual home dir.

### DIFF
--- a/app/models/concerns/local_log_file.rb
+++ b/app/models/concerns/local_log_file.rb
@@ -34,7 +34,7 @@ module LocalLogFile
     #   cmds = ["my_command", "'foo=bar lazy=true'"] will fail
     # The correct way is
     #   cmds = ["my_command", "foo=bar lazy=true"]
-    @last_child = POSIX::Spawn::Child.new(env.merge("HOME" => working_directory), *cmds, execute_options)
+    @last_child = POSIX::Spawn::Child.new(env, *cmds, execute_options)
 
     log_stdout(last_child.out)
     log_stderr(last_child.err)

--- a/app/models/deployment/credentials.rb
+++ b/app/models/deployment/credentials.rb
@@ -1,10 +1,6 @@
 # Top-level class for Deployments.
 class Deployment
-  # Private: Setup ssh and netrc in a deployment specific directory
-  #
-  # This allows commands to be executed inside of the deployment directory with
-  # the HOME environmental variable changed. This makes git and ssh work
-  # without worrying about impacting other deployment processes.
+  # Set up ssh and netrc in the user's home directory
   class Credentials
     include ApiClient
 

--- a/lib/heaven/provider/default_provider.rb
+++ b/lib/heaven/provider/default_provider.rb
@@ -17,7 +17,7 @@ module Heaven
         @guid        = guid
         @name        = "unknown"
         @data        = data
-        @credentials = ::Deployment::Credentials.new(working_directory)
+        @credentials = ::Deployment::Credentials.new(File.expand_path("~"))
       end
 
       def output


### PR DESCRIPTION
This solves a problem that was happening on Heroku's cedar-14 stack.
Openssh was using the home directory from /etc/passwd instead of the
home directory from $HOME.

Closes #192 

Something to note:  I'm doing 2 things: Putting the SSH key in the actual home directory, and removing the overriding of the HOME env var.

I tried doing this without removing the HOME env var overriding behavior, but it turns out that Fabric (and the underlying paramiko ssh library) actually respects the value of the HOME environment variable when looking for the ssh config, even when SSH itself does not.  Go figure.