### PR TITLE
Updating Dockerfile to the 2.3.1 version of Ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.0
+FROM ruby:2.3.1
 MAINTAINER emdentec ltd. <docker@emdentec.com>
 
 RUN mkdir -p /root/.ssh


### PR DESCRIPTION
If we try to build the current version we get this error:

    Warning: the running version of Bundler is older than the version that created the lockfile. We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
    Your Ruby version is 2.3.0, but your Gemfile specified 2.3.1

Updating the ruby version as suggested by the error message.